### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "locate-java-home": "^1.1.2",
-    "node-gyp": "^4.0.0",
-    "npm": "^6.9.0"
+    "node-gyp": "^4.0.0"
   }
 }


### PR DESCRIPTION

Hello blackBoyCode!

It seems like you have npm as one of your (dev-) dependency in local-tcp-server-nodejs.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
